### PR TITLE
Update jitpack.yml & .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 /node_modules
 /android/src/**/res
 /android/src/**/kotlin
-android/.gradle/
+/android/build
+/android/.gradle/
 /css
 /less
 /package-lock.json

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,6 @@
 env:
   NODE_VERSION: "12.22.1"
   NODE_SHA256: "d315c5dea4d96658164cdb257bd8dbb5e44bdd2a7c1d747841f06515f23a0042"
-  GRADLE_VERSION: "6.5"
   GRADLE_SHA256: "23e7d37e9bb4f8dabb8a3ea7fdee9dd0428b9b1a71d298aefd65b11dccea220f"
 before_install:
   - wget -q https://nodejs.org/dist/v"$NODE_VERSION"/node-v"$NODE_VERSION"-linux-x64.tar.gz
@@ -9,11 +8,6 @@ before_install:
   - tar -xf node-v"$NODE_VERSION"-linux-x64.tar.gz
   - rm -f node-v"$NODE_VERSION"-linux-x64.tar.gz
   - export PATH=$PATH:`pwd`/node-v"$NODE_VERSION"-linux-x64/bin
-  - wget -q https://services.gradle.org/distributions/gradle-"$GRADLE_VERSION"-bin.zip
-  - echo "$GRADLE_SHA256" gradle-"$GRADLE_VERSION"-bin.zip | sha256sum -c
-  - unzip -q gradle-"$GRADLE_VERSION"-bin.zip
-  - rm -f gradle-"$GRADLE_VERSION"-bin.zip
-  - ./gradle-6.5/bin/gradle --offline wrapper
   - npm i
   - npm run build
   - cp -r ./android/* .


### PR DESCRIPTION
Since gradle is now included in the project (as it should), there's no more need to download gradle as a step part in the CI/CD pipeline.